### PR TITLE
Use MediaStreamTrack.stop() rather than MediaStream.stop()

### DIFF
--- a/webcall/js/webCall-client.js
+++ b/webcall/js/webCall-client.js
@@ -152,8 +152,12 @@ $.extend(WebCall.Client.prototype, {
             }
 
             if (this._localMediaStream) {
-                if (!this._localMediaStream.fake)
-                    this._localMediaStream.stop();
+                if (!this._localMediaStream.fake) {
+                    var tracks = this._localMediaStream.getTracks();
+                    tracks.forEach(function(element, index, array) {
+                        element.stop();
+                    });
+                }
 
                 this._localMediaStream = null;
             }


### PR DESCRIPTION
per https://developers.google.com/web/updates/2015/07/mediastream-deprecations

Hi, I've been seeing deprecation warnings in Google Chrome about MediaStream.stop(), claiming that it will not be supported as of version 47, coming out around "November 2015." 

I'm not well-versed in MediaStreams, so this might not be the ideal fix. But I thought I'd share it as a pull request rather than just send a support inquiry. 

Thanks (again) for the WebCall client code. We're enjoying being able to just click a button to join a conference. 
